### PR TITLE
Polish keyboard layout for Cosmo

### DIFF
--- a/symbols/planet_vndr/cosmo
+++ b/symbols/planet_vndr/cosmo
@@ -1236,3 +1236,55 @@ xkb_symbols "hu" {
 
     key <AB08>  { [     comma,   question, XF86Option,   multiply ] };
 };
+
+default  partial alphanumeric_keys
+xkb_symbols "pl" {
+    include "planet_vndr/cosmo(modifiers)"
+    include "planet_vndr/cosmo(common_keys)"
+
+    name[Group1]="Gemini Polish";
+
+    key <AE01> { [ 1,     	exclam,     	grave,  F1 ] };
+    key <AE02> { [ 2,   	at,           	asciitilde,  F2 ] };
+    key <AE03> { [ 3,   	numbersign,   	backslash,  F3 ] };
+    key <AE04> { [ 4,     	dollar,   		bar,  F4 ] };
+    key <AE05> { [ 5,    	percent,     	less,  F5 ] };
+    key <AE06> { [ 6,  		asciicircum,  	greater,  F6 ] };
+    key <AE07> { [ 7,      	ampersand,  	bracketleft,  F7 ] };
+    key <AE08> { [ 8,  		asterisk, 		bracketright,  F8 ] };
+    key <AE09> { [ 9, 		parenleft,    	braceleft,  F9 ] };
+    key <AE10> { [ 0,      	parenright,   	braceright, F10 ] };
+
+    key <AD01> { [ q, Q, 		q, 			Q ] };
+    key <AD02> { [ w, W, 		w, 			W ] };
+    key <AD03> { [ e, E, 		eogonek, 	Eogonek ] };
+    key <AD04> { [ r, R,        Print, 		registered ] };
+    key <AD05> { [ t, T,  		t, 			yen ] };
+    key <AD06> { [ y, Y,     	plus, 		rightarrow ] };
+    key <AD07> { [ u, U,  		EuroSign, 	uparrow ] };
+    key <AD08> { [ i, I,    	minus, 		plusminus ] };
+    key <AD09> { [ o, O,  		oacute, 	Oacute ] };
+    key <AD10> { [ p, P,      	equal, 		THORN ] };
+
+    key <AC01> { [      a,      A,    	aogonek, 	Aogonek ] };
+    key <AC02> { [      s,      S, 		sacute, 	Sacute ] };
+    key <AC03> { [      d,      D,     	d, 			ETH ] };
+    key <AC04> { [      f,      F,  	f, 			ordfeminine ] };
+    key <AC05> { [      g,      G,  	underscore, ENG ] };
+    key <AC06> { [      h,      H,  	notsign, 	dead_diaeresis ] };
+    key <AC07> { [      j,      J, 		underscore, dead_circumflex ] };
+    key <AC08> { [      k,      K, 		colon, 		degree ] };
+    key <AC09> { [      l,      L, 		lstroke, 	Lstroke ] };
+    key <AC11> { [ apostrophe, quotedbl, semicolon, Ccedilla ] };
+
+    key <AB01> { [      z,     Z, 		zabovedot, 	Zabovedot ] };
+    key <AB02> { [      x,     X, 		zacute, 	Zacute ] };
+    key <AB03> { [      c,     C, 		cacute, 	Cacute ] };
+    key <AB04> { [      v,     V,  		v, 			leftsinglequotemark ] };
+    key <AB05> { [      b,     B, 		b, 			rightsinglequotemark ] };
+    key <AB06> { [      n,     N,  		nacute, 	Nacute ] };
+    key <AB07> { [      m,     M,  		m, 			dead_grave ] };
+    key <AB09> { [ period, question, 	period, 	dead_tilde ] };
+
+    key <AB08> { [ comma, slash, comma, multiply ] };
+};

--- a/symbols/planet_vndr/cosmo
+++ b/symbols/planet_vndr/cosmo
@@ -1242,7 +1242,7 @@ xkb_symbols "pl" {
     include "planet_vndr/cosmo(modifiers)"
     include "planet_vndr/cosmo(common_keys)"
 
-    name[Group1]="Gemini Polish";
+    name[Group1]="Cosmo Polish";
 
     key <AE01> { [ 1,     	exclam,     	grave,  F1 ] };
     key <AE02> { [ 2,   	at,           	asciitilde,  F2 ] };


### PR DESCRIPTION
Without the media keys as noticed those were removed for now, so just standard special keys to match what is printed on keys